### PR TITLE
Current implementation of alloc is unsound.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 license = "CC0-1.0"
 name = "bump_alloc"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Neil Henning <sheredom@gmail.com>"]
 edition = "2018"
 description = "global_allocator implementation of a bump allocator"
@@ -10,9 +10,14 @@ readme = "README.md"
 keywords = ["bump", "allocator", "GlobalAlloc", "global_allocator"]
 
 [dependencies]
-kernel32-sys = "0.2.1"
-libc = "0.2.46"
-winapi = { version = "0.3.6", features = ["minwindef", "winnt"] }
+once_cell = "1.4.1"
+
+[target.'cfg(unix)'.dependencies]
+libc = "0.2.76"
+
+[target.'cfg(windows)'.dependencies]
+kernel32-sys = "0.2.2"
+winapi = { version = "0.3.9", features = ["minwindef", "winnt"] }
 
 [badges]
 travis-ci = { repository = "sheredom/bump_alloc" }


### PR DESCRIPTION
The current implementation of `alloc` is unsound for several reasons:

 1. It creates a `&mut Inner` out of the `UnsafeCell` _before_ any synchronization, thus allowing multiple aliasing `&mut` references, which is UB. 

 1. It uses `Relaxed` memory orderings even though the atomics were supposed to protect the `.mmap` field for its lazy-initialization pattern.

 1. The alignment check is performed on an offset, thus assuming an "infinitely" aligned `mmap`-originated pointer. Although it is true that `mmap` does usually yields pages 4Kb-aligned, technically the user could query something with an even _higher_ alignment requirement.

 1. If somebody queries an absurdingly large allocation, the size checks can wrap / overflow the integer space, and succeed.

___

Since I am not fond of "criticizing" without anything constructive on the other side, here is a PR that aims to fix those things:

 1. It uses `once_cell` for a safe lazy initialization of `.mmap`.

 1. **It does still use a `Relaxed` ordering**, which could still be an issue. But given the current implementation, I don't see the atomics having to syncrhonize with / protect any "raw" value, so I really can't see how `Relaxed` can be an issue anymore. But would welcome a code review in that regard;

 1. It does perform the alignment check on the to-be-yielded pointer,

 1. and does check for overflow as often as it is necessary.

  - But because of these two last things, a simple `.fetch_add` is no longer doable, since we need to check our newly computed offset is "correct" before writing anything. Otherwise another thread could see the absurd offset value in between, and operate off that. I have gone for a CAS-based implementation, which may be suboptimal in case of high contention, but has the benefit of being correct / sound, and of never deadlocking.

  - I have also replaced `handle_alloc_error()` calls with returned `NULL`s, since, IIUC, it is for the caller of the allocation function to decide how to handle an allocation error (signaled through a `NULL` pointer). Granted, if `mmap` or equivalent fail, returning `NULL` seems overly silent...

  - I have checked the code compiles fine and the tests pass on Rust 1.36.0 (there does not seem to be any mention of MSRV anywhere).